### PR TITLE
support drip in panc script

### DIFF
--- a/panc/src/main/scripts/panc
+++ b/panc/src/main/scripts/panc
@@ -11,6 +11,14 @@ if [ ! -x $javaexe ]; then
 	exit 1
 fi
 
+if [ -n "$DRIP" ]; then
+    javaexe=`which drip`
+    if [ ! -x $javaexe ]; then
+        echo " ERROR: cannot find executable for drip"
+        exit 1
+    fi
+fi
+
 jopts=""
 if [ -n $JAVA_OPTS ]; then
     jopts=$JAVA_OPTS


### PR DESCRIPTION
Support for drip (https://github.com/flatland/drip) JVM startup.
Causes significant speedup in the core component unittests (lots of `panc` calls).