### PR TITLE
Documentation: Switch default code highlighter to pan

### DIFF
--- a/panc-docs/source/commands/commands.rst
+++ b/panc-docs/source/commands/commands.rst
@@ -232,7 +232,7 @@ then the following R script will do a simple analysis of the results.
 This will provide statistical results on the various build phases and
 show histograms of the distributions.
 
-::
+.. code-block:: r
 
     # R-script for simple analysis of build report
     bstats <- read.table("build.txt")
@@ -317,7 +317,7 @@ information. This graph shows a vertical line for each compilation,
 where the horizontal location is related to the start time and the
 height of the line the duration.
 
-::
+.. code-block:: r
 
     # R-script for simple analysis of compile report
     cstats <- read.table("compile.txt")
@@ -363,7 +363,7 @@ If the output from the command is written to the file ``memory.txt``,
 then the following R script will create a plot of the memory utilization
 as a function of time.
 
-::
+.. code-block:: r
 
     # R-script for simple analysis of memory report
     mstats <- read.table("memory.txt")
@@ -447,7 +447,7 @@ If the output from the command is written to the file ``thread.txt``,
 then the following R script will create a plot showing the duration of
 the activity on each thread.
 
-::
+.. code-block:: r
 
     # R-script for simple analysis of thread report
     tstats <- read.table("threads.txt")

--- a/panc-docs/source/obtaining/obtain-panc.rst
+++ b/panc-docs/source/obtaining/obtain-panc.rst
@@ -19,7 +19,9 @@ Source
 ======
 
 The source for the pan compiler is managed through a git repository on
-GitHub. The software can be checked out with the following command::
+GitHub. The software can be checked out with the following command
+
+.. code-block:: sh
 
     git clone git://github.com/quattor/pan.git
 
@@ -29,7 +31,9 @@ compiler can be provided via GitHub pull requests.
 The master branch is the main development branch. Although an effort is
 made to ensure that this code functions correctly, there may be times
 when it is broken. Released versions can be found through the named
-branches and tags. Use the git commands::
+branches and tags. Use the git commands
+
+.. code-block:: sh
 
     git branch -r
     git tag -l
@@ -48,18 +52,22 @@ Oracle. Maven can be obtained from the Apache Foundation web site.
 
 The build of the compiler is done via Apache Maven that also depends on
 Java. For Maven to find the correct version of the compiler, the
-environment variable JAVA\_HOME should be defined::
+environment variable JAVA\_HOME should be defined
+
+.. code-block:: sh
 
     export JAVA_HOME=<path to java area>
 
 or
 
-::
+.. code-block:: sh
 
     setenv JAVA_HOME <path to java area>
 
 depending on the type of shell that you use. After that, the entire
-build can be accomplished with::
+build can be accomplished with
+
+.. code-block:: sh
 
     mvn clean package
 

--- a/panc-docs/source/pan-book/pan-book.rst
+++ b/panc-docs/source/pan-book/pan-book.rst
@@ -99,7 +99,7 @@ Java Virtual Machine.
 To use the compiler from the command line, you must make it accessible
 from the path.
 
-::
+.. code-block:: sh
 
     $ export PANC_HOME=/panc/location
     $ export PATH=$PANC_HOME/bin:$PATH
@@ -113,7 +113,9 @@ Validating the Installation
 ---------------------------
 
 Once you have installed the compiler, make sure that it is working
-correctly by using the command::
+correctly by using the command
+
+.. code-block:: sh
 
     $ panc --help
 
@@ -124,7 +126,9 @@ Invoking the Pan Compiler
 -------------------------
 
 Now create a file (called a "template") named ``hello_world.pan`` that
-contains the following::
+contains the following
+
+::
 
     object template hello_world;
     '/message' = 'Hello World!';
@@ -132,7 +136,7 @@ contains the following::
 Compile this template into the default XML representation and look at
 the output.
 
-::
+.. code-block:: sh
 
     $ panc hello_world.pan
 
@@ -154,7 +158,7 @@ The pan compiler can generate output in three additional formats: json,
 text, and dot. The following shows the output for the json format that
 was written to the ``hello_world.json`` file.
 
-::
+.. code-block:: sh
 
     $ panc --formats json hello_world.pan
 
@@ -167,7 +171,7 @@ In this book, the most convenient representation is the text format.
 This provides a clean representation of the configuration tree in plain
 text.
 
-::
+.. code-block:: sh
 
     $ panc --formats text hello_world.pan
 
@@ -180,7 +184,7 @@ information as the other formats, but is easier to read.
 
 The last style is the "dot" format.
 
-::
+.. code-block:: sh
 
     $ panc --formats dot hello_world.pan
 
@@ -298,14 +302,14 @@ This is part of the cluster controlled by the server
 
 These templates can be compiled with the following command:
 
-::
+.. code-block:: pan
 
     $ panc --formats text *.pan
 
 which then produces the files ``server.example.org.txt`` and
 ``worker01.example.org.txt``:
 
-::
+.. code-block:: none
 
     +-profile
       +-batch
@@ -321,7 +325,7 @@ which then produces the files ``server.example.org.txt`` and
             +-default
               $ maxCpuHours : (long) '1'
 
-::
+.. code-block:: none
 
     +-profile
       +-batch
@@ -399,7 +403,7 @@ listing the services included on the machine.
 
 The command to compile these object templates is slightly different:
 
-::
+.. code-block:: sh
 
     $ panc --formats text profiles/*.pan
 
@@ -2715,7 +2719,9 @@ the ``--base-dir`` option if this is not the current directory.
 ``--base-dir`` option must be adjusted so that the template file paths
 specified match the template namespaces, as for compiling the templates.
 
-Below is an example::
+Below is an example
+
+.. code-block:: sh
 
     $ panc-annotations \
               --output-dir=annotations \
@@ -2728,7 +2734,7 @@ indentation added for clarity) in the file
 template file ``example.pan`` located in subdirectory
 ``templates/mysite`` of current directory.
 
-::
+.. code-block:: xml
 
     <?xml version="1.0" encoding="UTF-8"?>
     <template xmlns="http://quattor.org/pan/annotations"
@@ -3152,7 +3158,9 @@ the section Running the Compiler for how to specify the VM memory.
 
 If the compilation appears to be slow, check that the compiler is not
 thrashing because of a limited amount of memory. With the verbose option
-set, successful compilations will produce a summary like::
+set, successful compilations will produce a summary like
+
+.. code-block:: none
 
     2 templates
     2/2 compiled, 2/2 xml, 0/0 dep

--- a/panc-docs/source/pan-book/pan-book.rst
+++ b/panc-docs/source/pan-book/pan-book.rst
@@ -139,8 +139,12 @@ the output.
 .. code-block:: sh
 
     $ panc hello_world.pan
-
     $ cat hello_world.xml
+
+Should give the following:
+
+.. code-block:: xml
+
     <?xml version="1.0" encoding="UTF-8"?>
     <nlist format="pan" name="profile">
         <string name="message">Hello World!</string>
@@ -161,8 +165,12 @@ was written to the ``hello_world.json`` file.
 .. code-block:: sh
 
     $ panc --formats json hello_world.pan
-
     $ cat hello_world.json
+
+Should give the following:
+
+.. code-block:: js
+
     {
       "message": "Hello World!"
     }
@@ -174,8 +182,12 @@ text.
 .. code-block:: sh
 
     $ panc --formats text hello_world.pan
-
     $ cat hello_world.txt
+
+Should give the following:
+
+.. code-block:: none
+
     +-profile
       $ message : (string) 'hello'
 
@@ -187,8 +199,12 @@ The last style is the "dot" format.
 .. code-block:: sh
 
     $ panc --formats dot hello_world.pan
-
     $ cat hello_world.dot
+
+Should give the following:
+
+.. code-block:: none
+
     digraph "profile" {
     bgcolor = beige
     node [ color = black, shape = box, fontname=Helvetica ]

--- a/panc-docs/source/pan-book/pan-book.rst
+++ b/panc-docs/source/pan-book/pan-book.rst
@@ -1,3 +1,4 @@
+.. highlight:: pan
 Getting Started
 ===============
 

--- a/panc-docs/source/running/running.rst
+++ b/panc-docs/source/running/running.rst
@@ -16,7 +16,9 @@ If the Java compiler class is being directly invoked via the ``java``
 command, then the option ``-Xmx`` must be used to change the VM memory
 available (for any reasonably sized compilation). For example to start
 ``java`` with 1024 MB of memory, the following command and options can
-be used::
+be used
+
+.. code-block:: sh
 
     java -Xmx1024M org.quattor.pan.Compiler [options...]
 
@@ -99,9 +101,13 @@ build process by doing the following::
 
 Again, this should end with a "BUILD SUCCESS". It will have generated
 the machine profile in the ``target/profiles/node.example.org.xml``
-file::
+file
+
+.. code-block:: sh
 
     $ cat target/profiles/node.example.org.xml
+
+.. code-block:: xml
 
     <?xml version="1.0" encoding="UTF-8"?>
     <nlist format="pan" name="profile">
@@ -121,7 +127,9 @@ file::
 
 The ``pom.xml`` file in the skeleton provides a good example on how to
 run the plug-in. You can also obtain more detailed help via the maven
-help system::
+help system
+
+.. code-block:: sh
 
     $ mvn help:describe -Dplugin=panc -Ddetail=true
 
@@ -180,7 +188,9 @@ Ant
 Using an ant task to invoke the compiler allows the compiler to be
 easily integrated with other machine management tasks. To use the pan
 compiler within an ant build file, the pan compiler tasks must be
-defined. This can be done with a task definition element like::
+defined. This can be done with a task definition element like
+
+.. code-block:: xml
 
     <target name="define.panc.task">
 
@@ -211,7 +221,9 @@ There are four tasks defined:
 ``panc-version``
     Displays the pan compiler version.
 
-Running the compiler can be done with tasks like the following::
+Running the compiler can be done with tasks like the following
+
+.. code-block:: xml
 
     <target name="compile.cluster.profiles">
 
@@ -220,23 +232,22 @@ Running the compiler can be done with tasks like the following::
         <dirset dir="${basedir}" includes="**/*" />
       </path>
 
-      <panc-check-syntax ...options... >
+      <panc-check-syntax OPTION="VALUE" >
         <fileset dir="${basedir}/profiles" casesensitive="yes" includes="*.pan" />
       </panc-check-syntax>
 
-      <panc ...options... >
+      <panc OPTION="VALUE" >
         <path refid="pan.loadpath" />
         <fileset dir="${basedir}/profiles" casesensitive="yes" includes="*.pan" />
       </panc>
 
-      <panc-annotations ...options... >
+      <panc-annotations OPTION="VALUE" >
         <fileset dir="${basedir}/profiles" casesensitive="yes" includes="*.pan" />
       </panc-annotations>
 
     </target>
 
-
-where ...options... is replaced with valid options (attributes) for the
+where ``OPTION="VALUE"`` is replaced with valid options (attributes) for the
 pan compiler ant tasks. The following tables describe all of the
 attributes supported by the these tasks (task ``panc-version`` accepts
 no option).
@@ -332,13 +343,13 @@ Setting JVM Parameters
 If the compiler is invoked via the pan compiler ant task, then the
 memory option can be added with the ANT\_OPTS environmental variable.
 
-::
+.. code-block:: sh
 
     export ="-Xmx1024M"
 
 or
 
-::
+.. code-block:: sh
 
     setenv  "-Xmx1024M"
 
@@ -351,14 +362,16 @@ Invocation Inside Eclipse
 
 If you use the default VM to run the pan compiler ant task, then you
 will need to increase the memory when starting eclipse. From the command
-line you can add the VM arguments like::
+line you can add the VM arguments like
+
+.. code-block:: sh
 
     eclipse -vmargs -Xmx<memory size>
 
 You may also need to increase the memory in the "permanent" generation
 for a Sun VM with
 
-::
+.. code-block:: sh
 
     eclipse -vmargs -XX:MaxPermSize=<memory size>
 


### PR DESCRIPTION
As this is pan documentation, most of the code snippets are pan!

The PanLexer has been in Pygments since 2.0, so we should make use of it where we can.