### PR TITLE
Resource protection should be deep, not shallow

### DIFF
--- a/panc/src/main/java/org/quattor/pan/dml/data/HashResource.java
+++ b/panc/src/main/java/org/quattor/pan/dml/data/HashResource.java
@@ -209,7 +209,11 @@ public class HashResource extends Resource {
 
 	@Override
 	public Resource.Iterator iterator() {
-		return new HashResourceIterator(map);
+		return new HashResourceIterator(map, false);
+	}
+
+	public Resource.Iterator protectedIterator() {
+		return new HashResourceIterator(map, true);
 	}
 
 	private static class HashResourceIterator implements Resource.Iterator {
@@ -218,9 +222,12 @@ public class HashResource extends Resource {
 
 		private final Map<String, Element> backingHash;
 
-		public HashResourceIterator(Map<String, Element> backingHash) {
+		private final boolean isProtected;
+
+		public HashResourceIterator(Map<String, Element> backingHash, boolean isProtected) {
 			assert (backingHash != null);
 			this.backingHash = backingHash;
+			this.isProtected = isProtected;
 			iterator = backingHash.keySet().iterator();
 		}
 
@@ -243,6 +250,9 @@ public class HashResource extends Resource {
 					throw new EvaluationException(
 							MessageUtils.format(MSG_CONCURRENT_MODIFICATION),
 							null);
+				}
+				if (isProtected) {
+					value = value.protect();
 				}
 				entry = new HashResourceEntry(key, value);
 			} catch (NoSuchElementException nsee) {

--- a/panc/src/main/java/org/quattor/pan/dml/data/ListResource.java
+++ b/panc/src/main/java/org/quattor/pan/dml/data/ListResource.java
@@ -202,7 +202,11 @@ public class ListResource extends Resource {
 
 	@Override
 	public Resource.Iterator iterator() {
-		return new ListResourceIterator(list);
+		return new ListResourceIterator(list, false);
+	}
+
+	public Resource.Iterator protectedIterator() {
+		return new ListResourceIterator(list, true);
 	}
 
 	@Override
@@ -290,9 +294,12 @@ public class ListResource extends Resource {
 
 		private final List<Element> backingList;
 
-		public ListResourceIterator(List<Element> backingList) {
+		private final boolean isProtected;
+
+		public ListResourceIterator(List<Element> backingList, boolean isProtected) {
 			assert (backingList != null);
 			this.backingList = backingList;
+			this.isProtected = isProtected;
 		}
 
 		public void remove() {
@@ -307,8 +314,14 @@ public class ListResource extends Resource {
 		public Resource.Entry next() {
 			try {
 				int i = index.getAndIncrement();
+
+				Element value = backingList.get(i);
+				if (isProtected && value != null) {
+					value = value.protect();
+				}
+
 				Resource.Entry entry = new ListResourceEntry(LongProperty.getInstance(i),
-						backingList.get(i));
+						value);
 				return entry;
 			} catch (NoSuchElementException nsee) {
 				throw new EvaluationException(MessageUtils

--- a/panc/src/main/java/org/quattor/pan/dml/data/ListResource.java
+++ b/panc/src/main/java/org/quattor/pan/dml/data/ListResource.java
@@ -286,7 +286,7 @@ public class ListResource extends Resource {
 
 	private static class ListResourceIterator implements Resource.Iterator {
 
-        private final AtomicInteger index = new AtomicInteger(0);
+	private final AtomicInteger index = new AtomicInteger(0);
 
 		private final List<Element> backingList;
 
@@ -306,10 +306,10 @@ public class ListResource extends Resource {
 
 		public Resource.Entry next() {
 			try {
-                int i = index.getAndIncrement();
+				int i = index.getAndIncrement();
 				Resource.Entry entry = new ListResourceEntry(LongProperty.getInstance(i),
 						backingList.get(i));
-                return entry;
+				return entry;
 			} catch (NoSuchElementException nsee) {
 				throw new EvaluationException(MessageUtils
 						.format(MSG_CONCURRENT_MODIFICATION), null);

--- a/panc/src/main/java/org/quattor/pan/dml/data/ProtectedHashResource.java
+++ b/panc/src/main/java/org/quattor/pan/dml/data/ProtectedHashResource.java
@@ -26,7 +26,11 @@ public class ProtectedHashResource extends HashResource {
 
 	@Override
 	public Element get(Term key) throws InvalidTermException {
-		return baseHash.get(key);
+		final Element value = baseHash.get(key);
+		if (value != null) {
+			return value.protect();
+		}
+		return value;
 	}
 
 	@Override
@@ -84,7 +88,12 @@ public class ProtectedHashResource extends HashResource {
 
 	@Override
 	public Resource.Iterator iterator() {
-		return baseHash.iterator();
+		return baseHash.protectedIterator();
+	}
+
+	@Override
+	public Resource.Iterator protectedIterator() {
+		return baseHash.protectedIterator();
 	}
 
 	@Override

--- a/panc/src/main/java/org/quattor/pan/dml/data/ProtectedListResource.java
+++ b/panc/src/main/java/org/quattor/pan/dml/data/ProtectedListResource.java
@@ -25,7 +25,11 @@ public class ProtectedListResource extends ListResource {
 
 	@Override
 	public Element get(Term key) throws InvalidTermException {
-		return baseList.get(key);
+		final Element value = baseList.get(key);
+		if (value != null) {
+			return value.protect();
+		}
+		return value;
 	}
 
 	@Override
@@ -45,7 +49,12 @@ public class ProtectedListResource extends ListResource {
 
 	@Override
 	public Resource.Iterator iterator() {
-		return baseList.iterator();
+		return baseList.protectedIterator();
+	}
+
+	@Override
+	public Resource.Iterator protectedIterator() {
+		return baseList.protectedIterator();
 	}
 
 	@Override

--- a/panc/src/main/java/org/quattor/pan/dml/data/ProtectedListResource.java
+++ b/panc/src/main/java/org/quattor/pan/dml/data/ProtectedListResource.java
@@ -43,6 +43,16 @@ public class ProtectedListResource extends ListResource {
 	}
 
 	@Override
+	public void append(Element e) {
+		throw CompilerError.create(MSG_ILLEGAL_WRITE_TO_PROTECTED_LIST);
+	}
+
+	@Override
+	public void prepend(Element e) {
+		throw CompilerError.create(MSG_ILLEGAL_WRITE_TO_PROTECTED_LIST);
+	}
+
+	@Override
 	public int size() {
 		return baseList.size();
 	}

--- a/panc/src/main/java/org/quattor/pan/parser/ASTBaseTypeSpec.java
+++ b/panc/src/main/java/org/quattor/pan/parser/ASTBaseTypeSpec.java
@@ -25,9 +25,9 @@ import org.quattor.pan.utils.Range;
 public class ASTBaseTypeSpec extends SimpleNode {
 
 	private Range range = null;
-	
+
 	private boolean extensible = false;
-	
+
 	private String identifier = null;
 
 	public ASTBaseTypeSpec(int id) {
@@ -45,19 +45,19 @@ public class ASTBaseTypeSpec extends SimpleNode {
 	public boolean isExtensible() {
 		return extensible;
 	}
-	
+
 	public void setIdentifier(String identifier) {
 		this.identifier = identifier;
 	}
-	
+
 	public String getIdentifier() {
 		return identifier;
 	}
-	
+
 	public void setRange(Range range) {
 		this.range = range;
 	}
-	
+
 	public Range getRange() {
 		return range;
 	}

--- a/panc/src/main/java/org/quattor/pan/parser/ASTFunction.java
+++ b/panc/src/main/java/org/quattor/pan/parser/ASTFunction.java
@@ -32,11 +32,11 @@ public class ASTFunction extends ASTOperation {
 	public ASTFunction(PanParser p, int id) {
 		super(p, id);
 	}
-	
+
 	public void setName(String name) {
 		this.name = name;
 	}
-	
+
 	public String getName() {
 		return name;
 	}

--- a/panc/src/main/java/org/quattor/pan/template/BuildContext.java
+++ b/panc/src/main/java/org/quattor/pan/template/BuildContext.java
@@ -459,7 +459,7 @@ public class BuildContext implements Context {
 		setGlobalVariable("OBJECT", sname, true);
 		setGlobalVariable("LOADPATH", new ListResource(), false);
 	}
-	
+
 	public String getObjectName() {
 		return (objectTemplate != null) ? objectTemplate.name : "unknown";
 	}

--- a/panc/src/main/java/org/quattor/pan/template/Context.java
+++ b/panc/src/main/java/org/quattor/pan/template/Context.java
@@ -133,7 +133,7 @@ public interface Context {
 	 * Set the name of the object template. Define the necessary variables.
 	 */
 	public void setObjectAndLoadpath();
-	
+
 	/**
 	 * Get the name of the object template.
 	 */

--- a/panc/src/main/java/org/quattor/pan/type/FullType.java
+++ b/panc/src/main/java/org/quattor/pan/type/FullType.java
@@ -65,7 +65,11 @@ public class FullType extends Type {
 		assert (baseType != null);
 
 		this.baseType = baseType;
-		this.defaultValue = defaultValue;
+		if (defaultValue != null) {
+			this.defaultValue = defaultValue.protect();
+		} else {
+			this.defaultValue = null;
+		}
 		this.dml = dml;
 	}
 

--- a/panc/src/test/pan/Functionality/global/global6.tpl
+++ b/panc/src/test/pan/Functionality/global/global6.tpl
@@ -1,0 +1,17 @@
+#
+# see if globals can be modified indirectly via iterators in dml
+#
+# @expect="/nlist[@name='profile']/list[@name='data']/*[1]/string[@name='a']='OK'"
+#
+object template global6;
+
+variable GLOBAL = list(nlist("a", "OK"));
+
+variable GLOBAL = {
+    foreach (idx; item; GLOBAL) {
+        item["a"] = "BAD";
+    };
+    SELF;
+};
+
+"/data" = GLOBAL;


### PR DESCRIPTION
This change addresses a concurrency problem, when two distinct threads
processing the same non-object template ended up modifying the same
HashResource object simultaneously, leading to TreeMap corruption, which
manifested itself as NullPointerException or compiler hang. The trigger
was a foreach() loop over a protected hash, which did not propagate
the protection down to the hash values; the stack trace leading for this
situation was:

     [panc] org.quattor.pan.dml.data.HashResource.put(HashResource.java:172)
     [panc] org.quattor.pan.dml.data.Resource.rput(Resource.java:131)
     [panc] org.quattor.pan.template.BuildContext.setLocalVariable(BuildContext.java:1298)
     [panc] org.quattor.pan.dml.operators.SetValue.execute(SetValue.java:170)
     [panc] org.quattor.pan.dml.operators.Assign.execute(Assign.java:65)
     [panc] org.quattor.pan.dml.operators.IfElse.execute(IfElse.java:109)
     [panc] org.quattor.pan.dml.DML.execute(DML.java:120)
     [panc] org.quattor.pan.dml.operators.Foreach.execute(Foreach.java:93)

Note there is a similar concurrency issue in
org.quattor.pan.type.RecordType.setDefaults(), which is _not_ addressed by this
patch. So this patch addresses, but does not completely solve, issues #6
and #56.

There is a visible side effect of this patch. There is the following
bit of code in the standard template library:

    variable DISK_VOLUME_PARAMS = {
      foreach (volume;params;DISK_VOLUME_PARAMS) {
        if ( (params['type'] == 'partition') &&
             (is_defined(DISK_PART_BY_DEV['changed_part_num'][params['device']])) ) {
          debug('Updating '+volume+' partition to new name/number: '+DISK_PART_BY_DEV['changed_part_num'][params['device']]);
          params['device'] = DISK_PART_BY_DEV['changed_part_num'][params['device']];
          params['final'] = true;
        };
      };
      SELF;
    };

The code iterates over and changes DISK_VOLUME_PARAMS, and expects the
changes to be visible in SELF. After this patch the above code will no
longer work, because DISK_VOLUME_PARAMS inside the DML block will have
copy-on-write semantics, changing it will not alter SELF. The foreach()
loop in the above code needs to be re-written to refrence SELF instead
of DISK_VOLUME_PARAMS.