### PR TITLE
Fix error message for undefined values

### DIFF
--- a/panc/src/main/java/org/quattor/pan/dml/data/ElementUtils.java
+++ b/panc/src/main/java/org/quattor/pan/dml/data/ElementUtils.java
@@ -37,7 +37,7 @@ public class ElementUtils {
             Resource r = (Resource) e;
             for (Resource.Entry entry : r) {
                 String rpath = locateUndefinedElement(entry.getValue());
-                String term = entry.getValue().toString();
+                String term = entry.getKey().toString();
                 if (rpath != null) {
                     return (!"".equals(rpath)) ? term + "/" + rpath : term;
                 }

--- a/panc/src/test/pan/Functionality/undef/undef1.pan
+++ b/panc/src/test/pan/Functionality/undef/undef1.pan
@@ -1,7 +1,7 @@
 #
 # undefined elements can't appear in XML
 #
-# @expect=org.quattor.pan.exceptions.ValidationException
+# @expect=org.quattor.pan.exceptions.ValidationException ".*element at /x is undefined.*"
 #
 
 object template undef1;

--- a/panc/src/test/pan/Functionality/undef/undef2.pan
+++ b/panc/src/test/pan/Functionality/undef/undef2.pan
@@ -1,7 +1,7 @@
 #
 # undef will trigger an error in most opertions
 #
-# @expect=org.quattor.pan.exceptions.EvaluationException
+# @expect=org.quattor.pan.exceptions.EvaluationException ".*arguments for add \(\+\) operation must be longs, doubles, or strings.*"
 #
 
 object template undef2;

--- a/panc/src/test/pan/Functionality/undef/undef3.pan
+++ b/panc/src/test/pan/Functionality/undef/undef3.pan
@@ -1,7 +1,7 @@
 #
 # undef cannot be used against the root resource
 #
-# @expect=org.quattor.pan.exceptions.EvaluationException
+# @expect=org.quattor.pan.exceptions.EvaluationException ".*root element cannot be replaced by element of type undef.*"
 #
 
 object template undef3;


### PR DESCRIPTION
The error message should contain the path to the element, not the whole
subtree.