### PR TITLE
Panlint: Add unit tests for whitespace after semicolons

### DIFF
--- a/panc/src/main/scripts/panlint/panlint.py
+++ b/panc/src/main/scripts/panlint/panlint.py
@@ -52,7 +52,7 @@ LINE_PATTERNS = {
     "Line is longer than %s characters" % LINE_LENGTH_LIMIT: re.compile(r'''^.{0,%s}(?P<error>.*?)$''' % LINE_LENGTH_LIMIT),
     "Commas should be followed by exactly one space": re.compile(r'(?P<error>,(?:\S|\s{2,}))'),
     "Whitespace before semicolon": re.compile(r'(?P<error>\s+;)'),
-    "Semicolons should be followed exactly one space or end-of-line": re.compile(r'(?P<error>;(?:\S|\s{2,}))'),
+    "Semicolons should be followed exactly one space or end-of-line": re.compile(r';(?P<error>(?:\S|\s{2,}))'),
 }
 
 TAB_ARROW = u'\u2192'

--- a/panc/src/main/scripts/panlint/tests.py
+++ b/panc/src/main/scripts/panlint/tests.py
@@ -99,44 +99,61 @@ class TestPanlint(unittest.TestCase):
         self.assertEqual(lc.whitespace_around_operators(bad_after, []), (False, dgn_after, 'Missing space after operator'))
         self.assertEqual(lc.whitespace_around_operators(bad_both, []), (False, dgn_both, 'Missing space before and after operator'))
 
+    def test_whitespace_after_semicolons(self):
+        bad_1 = 'foreach(k; v;  things) {'
+        dgn_1 = ['             ^^']
+        msg_1 = ['Semicolons should be followed exactly one space or end-of-line']
+        self.assertEqual(
+            panlint.lint_line(bad_1, 1, [], False),
+            (dgn_1, set(msg_1), 1, False)
+        )
+
+        bad_2 = 'foreach(k;    v;  things) {'
+        dgn_2 = ['          ^^^^', '                ^^']
+        msg_2 = ['Semicolons should be followed exactly one space or end-of-line']
+        self.assertEqual(
+            panlint.lint_line(bad_2, 2, [], False),
+            (dgn_2, set(msg_2), 2, False)
+        )
+
     def test_lint_line(self):
         good_first = 'structure template foo.bar;'
         bad_first = 'variable foo = "bar";'
 
         # Test first line checking
-        self.assertEqual(panlint.lint_line(good_first, 1, [], True), ([], [], 0, False))
+        self.assertEqual(panlint.lint_line(good_first, 1, [], True), ([], set(), 0, False))
 
         diagnoses, messages, problem_count, first_line = panlint.lint_line(bad_first, 1, [], True)
         self.assertEqual(diagnoses, ['^'*len(bad_first)])
-        self.assertNotEqual(messages, [])
+        self.assertNotEqual(messages, set())
         self.assertEqual(problem_count, 1)
         self.assertEqual(first_line, False)
 
         # Test component inclusion check
         diagnoses, messages, problem_count, first_line = panlint.lint_line('"/software/components/foo/bar" = 42;', 7, [], False)
         self.assertEqual(diagnoses, ['                      ^^^'])
-        self.assertNotEqual(messages, [])
+        self.assertNotEqual(messages, set())
         self.assertEqual(problem_count, 1)
         self.assertEqual(first_line, False)
 
         # Test pattern based checking
         diagnoses, messages, problem_count, first_line = panlint.lint_line('   x = x + 1; # Bad Indentation', 7, [], False)
         self.assertEqual(diagnoses, ['^^^'])
-        self.assertNotEqual(messages, [])
+        self.assertNotEqual(messages, set())
         self.assertEqual(problem_count, 1)
         self.assertEqual(first_line, False)
 
         # Test method based checking
         diagnoses, messages, problem_count, first_line = panlint.lint_line('x = x+1; # Missing space', 7, [], False)
         self.assertEqual(diagnoses, ['    ^^^'])
-        self.assertNotEqual(messages, [])
+        self.assertNotEqual(messages, set())
         self.assertEqual(problem_count, 1)
         self.assertEqual(first_line, False)
 
         # Test that all three check types co-exist
         diagnoses, messages, problem_count, first_line = panlint.lint_line('  "/software/components/foo/bar" = 42+7;', 7, [], False)
         self.assertItemsEqual(diagnoses, ['^^', '                        ^^^', '                                    ^^^'])
-        self.assertNotEqual(messages, [])
+        self.assertNotEqual(messages, set())
         self.assertEqual(problem_count, 3)
         self.assertEqual(first_line, False)
 


### PR DESCRIPTION
This uncovered a bug when multiple instances of a single error are present on the same line, which ignored all but the first match.