### PR TITLE
Panlint: fix whitespace checks

### DIFF
--- a/panc/src/main/scripts/panlint/panlint.py
+++ b/panc/src/main/scripts/panlint/panlint.py
@@ -278,8 +278,8 @@ def strip_trailing_comments(line, string_ranges):
         # If so, it's not really a comment.
         if not inside_string(comment.start(), comment.start()+1, string_ranges):
             debug_range(comment.start(), comment.end(), 'Comment', False)
-            line = line[:comment.start()]
-    return line.rstrip()
+            line = line[:comment.start()].rstrip()
+    return line
 
 
 def check_line_component_use(line, components_included):

--- a/panc/src/main/scripts/panlint/panlint.py
+++ b/panc/src/main/scripts/panlint/panlint.py
@@ -118,11 +118,11 @@ class LineChecks:
 
             elif not inside_string(start, end, string_ranges):
                 reason = 'Missing'
-                if chars_before[-1] not in (' ', '\t'):
+                if chars_before and chars_before[-1] not in (' ', '\t'):
                     valid = False
                     messages.add('before')
                     start -= 1
-                if chars_after[0] not in (' ', '\t'):
+                if chars_after and chars_after[0] not in (' ', '\t'):
                     valid = False
                     messages.add('after')
                     end += 1

--- a/panc/src/main/scripts/panlint/tests.py
+++ b/panc/src/main/scripts/panlint/tests.py
@@ -113,6 +113,10 @@ class TestPanlint(unittest.TestCase):
         self.assertEqual(lc.whitespace_around_operators(bad_negative, []),
                          (False, dgn_negative, 'Unwanted space after minus sign (not operator)'))
 
+        # Handling lines that start or end with an operator (i.e. are part of a multi-line expression) should be allowed
+        self.assertEqual(lc.whitespace_around_operators('+ 42;', []), (True, '', ''))
+        self.assertEqual(lc.whitespace_around_operators('variable x = 42 +', []), (True, '', ''))
+
     def test_whitespace_after_semicolons(self):
         bad_1 = 'foreach(k; v;  things) {'
         dgn_1 = ['             ^^']


### PR DESCRIPTION
* Don't helpfully strip trailing white-space before checking for it.
* Don't crash if there are no characters before or after an operator.