### PR TITLE
panc: set minimal surefire plugin version to pass JUnit

### DIFF
--- a/panc/pom.xml
+++ b/panc/pom.xml
@@ -78,6 +78,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.20</version>
         <configuration>
           <systemPropertyVariables>
             <panc.tmpdir>${project.build.directory}/test-tmp/tmpdir</panc.tmpdir>


### PR DESCRIPTION
To workaround the failing jenkins unittests of the master branch, eg
```
[xUnit] [INFO] - Starting to record.
[xUnit] [INFO] - Processing JUnit
[xUnit] [INFO] - [JUnit] - 154 test report file(s) were found with the pattern '*/target/surefire-reports/*xml' relative to '/var/lib/jenkins/jobs/panc/workspace' for the testing framework 'JUnit'.
[xUnit] [ERROR] - The result file '/var/lib/jenkins/jobs/panc/workspace/panc/target/surefire-reports/TEST-org.quattor.ant.DebugPatternsTest.xml' for the metric 'JUnit' is not valid. The result file has been skipped.
[xUnit] [INFO] - Failing BUILD because 'set build failed if errors' option is activated.
[xUnit] [INFO] - There are errors when processing test results.
[xUnit] [INFO] - Skipping tests recording.
[xUnit] [INFO] - Stop build.
```
