### PR TITLE
panc: only allow digit-only string as candidate list index (and allow anything else as dict key)

### DIFF
--- a/panc-docs/source/pan-book/pan-book.rst
+++ b/panc-docs/source/pan-book/pan-book.rst
@@ -1383,17 +1383,21 @@ same children from one compilation to the next.
 
 Within a given path, lists and dicts can be distinguished by the names
 of their children. Lists always have children whose names are valid long
-literals. In the following example, ``/mylist`` is a list with three
-children::
+literals. In the following example, ``/mylist`` is a list with one
+child::
 
     object template mylist;
 
     '/mylist/0' = 'decimal index';
-    '/mylist/01' = 'octal index';
-    '/mylist/0x2' = 'hexadecimal index';
 
-The indices can be specified in decimal, octal, or hexadecimal. The
-names of children in an dict must begin with a letter or underscore.
+
+The indices can be specified in decimal (digits only).
+Leading ``0``(s) (e.g. octal notation) are considered ambiguous
+and as such invalid.
+The names of children in an dict can be any string that has at
+least one non-digit character, starts with a so-called ``word``-character
+(``a-zA-Z0-9_``) and is followed by (zero or more) word-characters
+or ``+-.``.
 
 Special Types
 -------------

--- a/panc/src/main/java/org/quattor/pan/utils/MessageUtils.java
+++ b/panc/src/main/java/org/quattor/pan/utils/MessageUtils.java
@@ -312,6 +312,8 @@ public class MessageUtils {
 
     public final static String MSG_CANNOT_LOCATE_OBJECT_TEMPLATE = "MSG_CANNOT_LOCATE_OBJECT_TEMPLATE";
 
+    public final static String MSG_INVALID_LEADING_ZEROS_INDEX = "MSG_INVALID_LEADING_ZEROS_INDEX";
+
     public final static String MSG_INDEX_EXCEEDS_MAXIMUM = "MSG_INDEX_EXCEEDS_MAXIMUM";
 
     public final static String MSG_INDEX_CANNOT_BE_NEGATIVE = "MSG_INDEX_CANNOT_BE_NEGATIVE";

--- a/panc/src/main/resources/org/quattor/pan/Messages.properties
+++ b/panc/src/main/resources/org/quattor/pan/Messages.properties
@@ -148,6 +148,7 @@ MSG_INVALID_SECOND_ARG_DEPRECATED=second argument of deprecated() must be a stri
 MSG_CANNOT_CREATE_OUTPUT_DIRECTORY=cannot create output directory: {0}
 MSG_CANNOT_LOCATE_TEMPLATE=cannot locate template named ''{0}''
 MSG_CANNOT_LOCATE_OBJECT_TEMPLATE=cannot locate object template named ''{0}''
+MSG_INVALID_LEADING_ZEROS_INDEX=index cannot start with leading zero(s): ''{0}''
 MSG_INDEX_EXCEEDS_MAXIMUM=index ({0,number}) exceeds largest permitted value ({1,number})
 MSG_INDEX_CANNOT_BE_NEGATIVE=index ({0,number}) cannot be negative
 MSG_KEY_CANNOT_BE_EMPTY_STRING=empty string cannot be used as a path term or nlist key

--- a/panc/src/test/java/org/quattor/pan/utils/PathTest.java
+++ b/panc/src/test/java/org/quattor/pan/utils/PathTest.java
@@ -116,8 +116,7 @@ public class PathTest {
 	@Test
 	public void testInvalidFirstTerm() {
 		List<String> paths = Arrays.asList("alpha:/0/a",
-				"alpha:0/a", "/0/a", "0/a", "alpha:/0xf/a",
-				"alpha:0xf/a", "/0xf/a", "0xf/a");
+				"alpha:0/a", "/0/a", "0/a");
 		for (String s : paths) {
 			try {
 				new Path(s);

--- a/panc/src/test/java/org/quattor/pan/utils/TermTest.java
+++ b/panc/src/test/java/org/quattor/pan/utils/TermTest.java
@@ -38,7 +38,7 @@ public class TermTest {
 	@Test
 	public void testLegalTerms() {
 		List<String> paths = Arrays.asList("a", "_", "_0", "_1", "a+", "a-",
-				"a.", "0", "1", "10", "00", "017", "0xff", "0XFF");
+				"a.", "0", "1", "10", "17", "0xff", "0XFF");
 		for (String s : paths) {
 			try {
 				TermFactory.create(s);
@@ -80,7 +80,8 @@ public class TermTest {
 
 	@Test
 	public void testIllegalTerms() {
-		List<String> paths = Arrays.asList("", "09", "0xfg", "0XFG", "-", "+",
+        /* 06: valid octal, 09: invalid octal, 00 and 017: previous valid in testLegalTerms */
+		List<String> paths = Arrays.asList("", "06", "09", "00", "017", "-", "+",
 				".", "-a", "+a", ".a");
 		for (String s : paths) {
 			try {

--- a/panc/src/test/pan/Functionality/path/path14.pan
+++ b/panc/src/test/pan/Functionality/path/path14.pan
@@ -1,0 +1,10 @@
+#
+# invalid path
+#
+# @expect=org.quattor.pan.exceptions.SyntaxException
+#
+
+object template path14;
+
+# leading 0s, even if they are valid octals, are invalid path terms
+"/foo/06" = 0;

--- a/panc/src/test/pan/Functionality/path/path6.pan
+++ b/panc/src/test/pan/Functionality/path/path6.pan
@@ -1,9 +1,0 @@
-#
-# invalid path
-#
-# @expect=org.quattor.pan.exceptions.SyntaxException
-#
-
-object template path6;
-
-"/foo/1x" = 0;


### PR DESCRIPTION
Fixes #156
This is backwards incompatible because eg hex and/or octal notations cannot be used anymore.
