### PR TITLE
annotations: add default to annotation for attribute type with a default

### DIFF
--- a/panc/src/main/java/org/quattor/pan/parser/PanParserAnnotationUtils.java
+++ b/panc/src/main/java/org/quattor/pan/parser/PanParserAnnotationUtils.java
@@ -18,7 +18,9 @@ import org.quattor.pan.exceptions.CompilerError;
 import org.quattor.pan.exceptions.EvaluationException;
 import org.quattor.pan.exceptions.SyntaxException;
 import org.quattor.pan.exceptions.SystemException;
+import org.quattor.pan.dml.Operation;
 import org.quattor.pan.parser.ASTStatement.StatementType;
+import org.quattor.pan.parser.ASTOperation.OperationType;
 import org.quattor.pan.template.SourceRange;
 import org.quattor.pan.utils.MessageUtils;
 import org.quattor.pan.utils.XmlUtils;
@@ -189,6 +191,22 @@ public class PanParserAnnotationUtils {
             addAttribute(atts, "extensible", node.isExtensible());
             addAttribute(atts, "range", node.getRange());
 
+        } else if (ast instanceof ASTOperation) {
+            ASTOperation node = (ASTOperation) ast;
+            if (ast.jjtGetParent() instanceof ASTOperation) {
+                ASTOperation parent = (ASTOperation) ast.jjtGetParent();
+                if (parent.getOperationType() == OperationType.DML &&
+                    parent.jjtGetParent() instanceof ASTOperation) {
+                    ASTOperation grandparent = (ASTOperation) parent.jjtGetParent();
+                    if (grandparent.getOperationType() == OperationType.DEFAULT) {
+                        if (node.getOperation() != null) {
+                            elementName = "default";
+                            addSourceRangeAttribute(atts, node);
+                            addAttribute(atts, "text", node.getOperation().toString());
+                        }
+                    }
+                }
+            }
         }
 
         return elementName;


### PR DESCRIPTION
Fixes #132 

```pan
object template a;

type mytype = {
    @{abc}
    'a' : long = 1
    'b' ? string = 'b'
    'c' ? boolean
};

"/a" = 1;
```

gives annotation

```xml
<?xml version="1.0" encoding="UTF-8"?><template xmlns="http://quattor.org/pan/annotations" name="a" source-range="1.1-1.18" type="OBJECT">
    <type name="mytype" source-range="3.1-8.2">
        <basetype source-range="3.15-8.1" extensible="false">
            <field name="a" source-range="5.5-5.7" required="true">
                <desc>abc</desc>
                <basetype name="long" source-range="5.11-5.14" extensible="false"/>
                <default source-range="5.18-5.18" text="1"/>
            </field>
            <field name="b" source-range="6.5-6.7" required="false">
                <basetype name="string" source-range="6.11-6.16" extensible="false"/>
                <default source-range="6.20-6.22" text="b"/>
            </field>
            <field name="c" source-range="7.5-7.7" required="false">
                <basetype name="boolean" source-range="7.11-7.17" extensible="false"/>
            </field>
        </basetype>
    </type>
</template>
```