### PR TITLE
panc: FileSystemSourceRepository: cache retrievePanSource

### DIFF
--- a/panc/src/main/java/org/quattor/pan/repository/FileSystemSourceRepositoryImpl.java
+++ b/panc/src/main/java/org/quattor/pan/repository/FileSystemSourceRepositoryImpl.java
@@ -15,6 +15,18 @@ public class FileSystemSourceRepositoryImpl extends
         this.includeDirectories = validateAndCopyIncludeDirectories(includeDirectories);
     }
 
+    // Override to benefit from caching
+    @Override
+    public SourceFile retrievePanSource(String name) {
+        return retrievePanSource(name, emptyRelativePaths);
+    }
+
+    // Override to benefit from caching
+    @Override
+    public SourceFile retrieveTxtSource(String name) {
+        return retrieveTxtSource(name, emptyRelativePaths);
+    }
+
     @Override
     public File lookupText(String name) {
         return lookupText(name, emptyRelativePaths);


### PR DESCRIPTION
Avoid expensive filesystem lookups from lookupSource, mainly in case of large number of include directories and/or loadpaths