### PR TITLE
panc: value function respects bind default

### DIFF
--- a/panc/src/test/pan/Functionality/value/value10.pan
+++ b/panc/src/test/pan/Functionality/value/value10.pan
@@ -1,0 +1,20 @@
+# @expect="/nlist[@name="profile"]/nlist[@name="base"]/long[@name="a"]=40 and /nlist[@name="profile"]/nlist[@name="value"]/long[@name="a"]=0 and /nlist[@name="profile"]/nlist[@name="base"]/long[@name="b"]=30 and /nlist[@name="profile"]/nlist[@name="value"]/long[@name="b"]=30 and /nlist[@name="profile"]/nlist[@name="base"]/long[@name="c"]=50 and /nlist[@name="profile"]/nlist[@name="value"]/long[@name="c"]=50"
+# @format=pan
+#
+object template value10;
+
+type x = {
+    'a' : long = 0
+    'b' : long = 10
+    'c' : long = 20
+};
+bind "/base" = x;
+
+"/base/c" ?= 50;
+
+"/base/b" = 30;
+"/value" = value("/base");
+
+# value and bind default do not change the actual value of /value
+# tested by default assignment
+"/base/a" ?= 40;

--- a/panc/src/test/pan/Functionality/value/value9.pan
+++ b/panc/src/test/pan/Functionality/value/value9.pan
@@ -1,4 +1,4 @@
-# @expect="/nlist[@name="profile"]/long[@name="undef"]=0 and /nlist[@name="profile"]/long[@name="value"]=5"
+# @expect="/nlist[@name="profile"]/long[@name="undef"]=0 and /nlist[@name="profile"]/long[@name="value"]=0"
 # @format=pan
 #
 object template value9;

--- a/panc/src/test/pan/Functionality/value/value9b.pan
+++ b/panc/src/test/pan/Functionality/value/value9b.pan
@@ -1,0 +1,10 @@
+# @expect="/nlist[@name="profile"]/long[@name="undef"]=0 and /nlist[@name="profile"]/long[@name="value"]=5"
+# @format=pan
+#
+object template value9b;
+
+"/undef" = undef;
+"/value" = value("/undef", 5);
+
+# bind after value has no effect
+bind "/undef" = long = 0;


### PR DESCRIPTION
Fixes #205 
Backwards incompatible because 
* no compilation failure when path is missing but default exists in bind
* there is also a modified unittest (`value9`) that gives different result when value of path is `undef` and bind default exists.
