### PR TITLE
Fix panlint for python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,29 @@
-language: java
-jdk:
-    - openjdk8
-
-cache:
-  directories:
-  - $HOME/.m2
-
-install:
-    - pip install -U --user prettytable colorama coverage coveralls Sphinx
-
-script:
-    - mvn clean install
-    - python panc/src/main/scripts/panlint/tests.py
-    - coverage run --source=panc/src/main/scripts/panlint --omit panc/src/main/scripts/panlint/tests.py panc/src/main/scripts/panlint/tests.py
-
-after_success: coveralls
+matrix:
+    include:
+        - language: java
+          jdk:
+              - openjdk8
+          cache:
+              directories:
+                  - $HOME/.m2
+          install:
+              - pip install -U --user Sphinx
+          script:
+              - mvn clean install
+        - language: python
+          python:
+              - 2.7
+          install:
+              - pip install -U prettytable colorama coverage coveralls
+          script:
+              - python panc/src/main/scripts/panlint/tests.py
+              - coverage run --source=panc/src/main/scripts/panlint --omit panc/src/main/scripts/panlint/tests.py panc/src/main/scripts/panlint/tests.py
+        - language: python
+          python:
+              - 3.6
+          install:
+              - pip install -U prettytable colorama coverage coveralls
+          script:
+              - python panc/src/main/scripts/panlint/tests.py
+              - coverage run --source=panc/src/main/scripts/panlint --omit panc/src/main/scripts/panlint/tests.py panc/src/main/scripts/panlint/tests.py
+          after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
-language: python
-python:
-- 2.7
+language: java
+jdk:
+    - openjdk8
 
-install: "pip install prettytable colorama coverage coveralls"
+cache:
+  directories:
+  - $HOME/.m2
 
-script: coverage run --source=panc/src/main/scripts/panlint --omit panc/src/main/scripts/panlint/tests.py panc/src/main/scripts/panlint/tests.py
+install:
+    - pip install -U --user prettytable colorama coverage coveralls Sphinx
+
+script:
+    - mvn clean install
+    - python panc/src/main/scripts/panlint/tests.py
+    - coverage run --source=panc/src/main/scripts/panlint --omit panc/src/main/scripts/panlint/tests.py panc/src/main/scripts/panlint/tests.py
 
 after_success: coveralls
-
-sudo: false

--- a/panc/src/main/scripts/panlint/panlint.py
+++ b/panc/src/main/scripts/panlint/panlint.py
@@ -160,8 +160,7 @@ class LineChecks:
             passed &= valid
 
         if not passed and messages:
-            messages = list(messages)
-            messages.sort(None, None, True)
+            messages = sorted(list(messages), key=None, reverse=True)
             message = '%s space %s operator' % (reason, ' and '.join(messages))
         return (passed, diagnosis.rstrip(), message)
 

--- a/panc/src/main/scripts/panlint/panlint.py
+++ b/panc/src/main/scripts/panlint/panlint.py
@@ -109,7 +109,7 @@ class LineChecks:
             #    also whitespace, those are invalid
             sqb_simple = r'\s\w\d+-'
 
-            sqb_before = re.search(r'[[]([' + sqb_simple + ']*)$', chars_before)
+            sqb_before = re.search(r'[\[]([' + sqb_simple + ']*)$', chars_before)
             sqb_after = re.search(r'^([' + sqb_simple + ']*)[]]', chars_after)
 
             valid = True

--- a/panc/src/main/scripts/panlint/panlint.py
+++ b/panc/src/main/scripts/panlint/panlint.py
@@ -17,6 +17,7 @@
 
 """Linter for the Pan language"""
 
+from __future__ import print_function
 import re
 import argparse
 from glob import glob
@@ -221,15 +222,15 @@ def print_diagnosis(diagnosis):
 def debug_line(line):
     """Print debug information for a processed line of an input file"""
     if DEBUG:
-        label = 'DEBUG: %04d %-12s |' % (line.number, '...')
-        print ''.join([Style.DIM, Fore.CYAN, label, Style.RESET_ALL, line.text.replace('\t', TAB_ARROW)])
+        label = 'DEBUG: %04d %-12s |' % (line_number, '...')
+        print(''.join([Style.DIM, Fore.CYAN, label, Style.RESET_ALL, line.text.replace('\t', TAB_ARROW)]))
 
 
 def debug_ignored_line(line):
     """Print debug information for an ignored line of an input file"""
     if DEBUG:
-        label = 'DEBUG: %04d %-12s |' % (line.number, 'Ignored')
-        print ''.join([Fore.CYAN, Style.DIM, label, Fore.RESET, line.text.replace('\t', TAB_ARROW), Style.RESET_ALL])
+        label = 'DEBUG: %04d %-12s |' % (line_number, 'Ignored')
+        print(''.join([Fore.CYAN, Style.DIM, label, Fore.RESET, line.text.replace('\t', TAB_ARROW), Style.RESET_ALL]))
 
 
 def debug_range(start, end, label, problem=False):
@@ -240,7 +241,7 @@ def debug_range(start, end, label, problem=False):
         color = Fore.CYAN
         if problem:
             color = Fore.RED
-        print ''.join([Style.DIM, Fore.CYAN, label, Style.BRIGHT, color, diagnosis, Style.RESET_ALL])
+        print(''.join([Style.DIM, Fore.CYAN, label, Style.BRIGHT, color, diagnosis, Style.RESET_ALL]))
 
 
 def diagnose(start, end):
@@ -250,10 +251,10 @@ def diagnose(start, end):
 
 def print_report(filename, line, diagnosis, message, vi=False):
     """Print a full report of all problems found with a single line of a processed file"""
-    print
-    print print_fileinfo(filename, line.number, message, vi=vi)
-    print print_line(line.text)
-    print print_diagnosis(diagnosis)
+    print('')
+    print(print_fileinfo(filename, line.number, message, vi=vi))
+    print(print_line(line.text))
+    print(print_diagnosis(diagnosis))
 
 
 def get_string_ranges(line):
@@ -511,7 +512,7 @@ def main():
     problem_stats = {}
 
     if not args.paths:
-        print 'No files were provided, not doing anything'
+        print('No files were provided, not doing anything')
         return 0
 
     for path in args.paths:
@@ -525,12 +526,12 @@ def main():
         print_report(*report, vi=args.vi)
 
     if args.table:
-        print
-        print 'Problem count per file:'
-        print filestats_table(problem_stats)
+        print('')
+        print('Problem count per file:')
+        print(filestats_table(problem_stats))
 
-    print
-    print '%d problems found in total' % problems_found
+    print('')
+    print('%d problems found in total' % problems_found)
 
     if args.always_exit_success:
         return 0

--- a/panc/src/main/scripts/panlint/panlint.py
+++ b/panc/src/main/scripts/panlint/panlint.py
@@ -526,12 +526,10 @@ def main():
         print_report(*report, vi=args.vi)
 
     if args.table:
-        print('')
-        print('Problem count per file:')
+        print('\nProblem count per file:')
         print(filestats_table(problem_stats))
 
-    print('')
-    print('%d problems found in total' % problems_found)
+    print('\n%d problems found in total' % problems_found)
 
     if args.always_exit_success:
         return 0

--- a/panc/src/main/scripts/panlint/panlint.py
+++ b/panc/src/main/scripts/panlint/panlint.py
@@ -18,11 +18,12 @@
 """Linter for the Pan language"""
 
 from __future__ import print_function
-import re
 import argparse
+import re
 from glob import glob
 from sys import stdout, exit as sys_exit
 from inspect import getmembers, ismethod
+import six
 from colorama import Fore, Style, init as colorama_init
 from prettytable import PrettyTable
 from colorama import Fore, Style, init as colorama_init
@@ -348,7 +349,7 @@ def check_line_patterns(line, string_ranges):
     messages = set()
     problem_count = 0
 
-    for message, pattern in LINE_PATTERNS.iteritems():
+    for message, pattern in six.iteritems(LINE_PATTERNS):
         matches = pattern.finditer(line.text)
         for match in matches:
             if match and match.group('error'):
@@ -376,7 +377,7 @@ def check_line_paths(line):
         path_start, path_end = path_match.span('path')
         path_string = line.text[path_start + 1:path_end - 1]
         debug_range(path_start, path_end, 'Path String', False)
-        for message, pattern in PATH_PATTERNS.iteritems():
+        for message, pattern in six.iteritems(PATH_PATTERNS):
             matches = pattern.finditer(path_string)
             for match in matches:
                 if match and match.group('error'):

--- a/panc/src/main/scripts/panlint/panlint.py
+++ b/panc/src/main/scripts/panlint/panlint.py
@@ -455,7 +455,8 @@ def lint_file(filename, allow_mvn_templates=False):
     reports = []
     file_problem_count = 0
 
-    raw_text = open(filename).read()
+    with open(filename) as f:
+        raw_text = f.read()
 
     first_line = True
     ignore_lines = []

--- a/panc/src/main/scripts/panlint/panlint.py
+++ b/panc/src/main/scripts/panlint/panlint.py
@@ -26,7 +26,6 @@ from inspect import getmembers, ismethod
 import six
 from colorama import Fore, Style, init as colorama_init
 from prettytable import PrettyTable
-from colorama import Fore, Style, init as colorama_init
 
 
 class Line(object):
@@ -222,14 +221,14 @@ def print_diagnosis(diagnosis):
 def debug_line(line):
     """Print debug information for a processed line of an input file"""
     if DEBUG:
-        label = 'DEBUG: %04d %-12s |' % (line_number, '...')
+        label = 'DEBUG: %04d %-12s |' % (line.number, '...')
         print(''.join([Style.DIM, Fore.CYAN, label, Style.RESET_ALL, line.text.replace('\t', TAB_ARROW)]))
 
 
 def debug_ignored_line(line):
     """Print debug information for an ignored line of an input file"""
     if DEBUG:
-        label = 'DEBUG: %04d %-12s |' % (line_number, 'Ignored')
+        label = 'DEBUG: %04d %-12s |' % (line.number, 'Ignored')
         print(''.join([Fore.CYAN, Style.DIM, label, Fore.RESET, line.text.replace('\t', TAB_ARROW), Style.RESET_ALL]))
 
 

--- a/panc/src/main/scripts/panlint/panlint.py
+++ b/panc/src/main/scripts/panlint/panlint.py
@@ -453,7 +453,6 @@ def lint_line(line, components_included, first_line=False, allow_mvn_templates=F
 
 def lint_file(filename, allow_mvn_templates=False):
     """Run lint checks against all lines of a file."""
-    global DEBUG
     reports = []
     file_problem_count = 0
 

--- a/panc/src/main/scripts/panlint/tests.py
+++ b/panc/src/main/scripts/panlint/tests.py
@@ -19,6 +19,7 @@ import glob
 import unittest
 from sys import argv
 from os.path import basename, dirname, join
+import six
 
 import panlint
 
@@ -112,7 +113,7 @@ class TestPanlint(unittest.TestCase):
             'fn2': 'variable a = afunction() + 31;',
             'for': 'for (idx = 31; idx >= 0; idx = idx - 1) {',
             'square_brackets': 'variable x = b[c-1];',
-            'negative':  'variable x = -1;',
+            'negative': 'variable x = -1;',
             # lines that start or end with an operator (i.e. are part of a multi-line expression) should be allowed
             'line_cont': '+ 42;',
             'line_to_be_cont': 'variable x = 42 +',
@@ -226,7 +227,7 @@ class TestPanlint(unittest.TestCase):
         self.assertEqual(panlint.lint_line(good_first, [], True), ([], set(), 0, False))
 
         diagnoses, messages, problem_count, first_line = panlint.lint_line(bad_first, [], True)
-        self.assertEqual(diagnoses, ['^'*len(bad_first.text)])
+        self.assertEqual(diagnoses, ['^' * len(bad_first.text)])
         self.assertNotEqual(messages, set())
         self.assertEqual(problem_count, 1)
         self.assertEqual(first_line, False)
@@ -270,7 +271,7 @@ class TestPanlint(unittest.TestCase):
             [],
             False,
         )
-        self.assertItemsEqual(diagnoses, [
+        six.assertCountEqual(self, diagnoses, [
             '^^',
             '                        ^^^',
             '                                    ^^^',
@@ -290,7 +291,7 @@ class TestPanlint(unittest.TestCase):
         'simon' : string = 'says';
         '''
 
-        self.assertItemsEqual(panlint.find_annotation_blocks(test_text), [2, 7])
+        six.assertCountEqual(self, panlint.find_annotation_blocks(test_text), [2, 7])
         self.assertEqual(panlint.find_annotation_blocks('template garbage;\n\n# Nothing to see here.\n\n'), [])
 
     def test_find_heredoc_blocks(self):
@@ -305,7 +306,7 @@ class TestPanlint(unittest.TestCase):
         EOFF
         '''
 
-        self.assertItemsEqual(panlint.find_heredoc_blocks(test_text), [4, 5, 8, 9])
+        six.assertCountEqual(self, panlint.find_heredoc_blocks(test_text), [4, 5, 8, 9])
         self.assertEqual(panlint.find_heredoc_blocks('template garbage;\n\n# Nothing to see here.\n\n'), [])
 
     def test_component_use(self):

--- a/panc/src/main/scripts/panlint/tests.py
+++ b/panc/src/main/scripts/panlint/tests.py
@@ -43,7 +43,8 @@ class TestPanlint(unittest.TestCase):
 
     def test_get_string_ranges(self):
         self.assertEqual(panlint.get_string_ranges(panlint.Line('', 1, '''there is a "string" in here''')), [(11, 19)])
-        self.assertEqual(panlint.get_string_ranges(panlint.Line('', 1, '''"string" + 'string' + something''')), [(0, 8), (11, 19)])
+        self.assertEqual(panlint.get_string_ranges(panlint.Line('', 1, '''"string" + 'string' + something''')),
+                         [(0, 8), (11, 19)])
 
     def test_merge_diagnoses(self):
         diag1 = ' ^'
@@ -157,7 +158,8 @@ class TestPanlint(unittest.TestCase):
 
         # Handling lines that start or end with an operator (i.e. are part of a multi-line expression) should be allowed
         self.assertEqual(lc.whitespace_around_operators(panlint.Line('', 9216, '+ 42;'), []), (True, '', ''))
-        self.assertEqual(lc.whitespace_around_operators(panlint.Line('', 10240, 'variable x = 42 +'), []), (True, '', ''))
+        self.assertEqual(lc.whitespace_around_operators(panlint.Line('', 10240, 'variable x = 42 +'), []),
+                         (True, '', ''))
 
     def test_whitespace_after_semicolons(self):
         bad_1 = panlint.Line('', 1, 'foreach(k; v;  things) {')
@@ -316,7 +318,8 @@ class TestPanlint(unittest.TestCase):
         line_standard_commented = panlint.Line('', 101, '# ' + line_standard.text)
 
         # Test a line setting a path prefix
-        line_prefix = panlint.Line('', 200, "prefix '/software/components/metaconfig/services/{/etc/sysconfig/fetch-crl}';")
+        line_prefix = panlint.Line('', 200,
+                                   "prefix '/software/components/metaconfig/services/{/etc/sysconfig/fetch-crl}';")
         diag_prefix = "                             ^^^^^^^^^^"
         line_prefix_commented = panlint.Line('', 201, '# ' + line_prefix.text)
 
@@ -355,7 +358,8 @@ class TestPanlint(unittest.TestCase):
             ('variable UNIVERSAL_TRUTH = 42;', []),
             ('variable BAD = -1;', ['Global variables should be five or more characters']),
             ('variable bad_long = ":-(";', ['Global variables should be uppercase']),
-            ('variable bad = "all lower";', ['Global variables should be uppercase', 'Global variables should be five or more characters']),
+            ('variable bad = "all lower";', ['Global variables should be uppercase',
+                                             'Global variables should be five or more characters']),
             ('variable tricky_onE = "Uhoh";', ['Global variables should be uppercase']),
             ('variable camelCase = "camels!";', ['Global variables should be uppercase']),
             ('variable TitleCase ?= -3;', ['Global variables should be uppercase']),


### PR DESCRIPTION
As Fedora 31 lets python point to python 3, it broke panlint. This PR makes sure that panlint works with both python 2 and 3.