### PR TITLE
panlint: Don't lint blank lines

### DIFF
--- a/panc/src/main/scripts/panlint/panlint.py
+++ b/panc/src/main/scripts/panlint/panlint.py
@@ -473,7 +473,7 @@ def lint_file(filename, allow_mvn_templates=False):
     for line_number, line_text in enumerate(raw_text.splitlines(), start=1):
         line = Line(filename, line_number, line_text.rstrip('\n'))
 
-        if line and line_number not in ignore_lines and not RE_COMMENT_LINE.match(line_text):
+        if line.text and line.number not in ignore_lines and not RE_COMMENT_LINE.match(line.text):
             diagnoses, messages, line_problem_count, first_line = lint_line(line, components_included, first_line,
                                                                             allow_mvn_templates)
             file_problem_count += line_problem_count

--- a/panc/src/main/scripts/panlint/test_files/test_good_before_first_line.pan
+++ b/panc/src/main/scripts/panlint/test_files/test_good_before_first_line.pan
@@ -1,0 +1,14 @@
+# ${license-info}
+# ${developer-info}
+# ${author-info}
+
+declaration template components/openstack/catalog;
+
+include 'components/openstack/catalog/murano';
+
+@documentation {
+Type to define OpenStack catalog services
+}
+type openstack_catalog_config = {
+    'murano' ? openstack_murano_config
+} with openstack_oneof(SELF, 'murano');

--- a/panc/src/main/scripts/panlint/tests.py
+++ b/panc/src/main/scripts/panlint/tests.py
@@ -61,7 +61,7 @@ class TestPanlint(unittest.TestCase):
         """
         no_errors = ([], 0)
         dir_base = join(dirname(argv[0]), 'test_files')
-        for afn in glob.glob(join(dir_base, '/test_*.pan')):
+        for afn in glob.glob(join(dir_base, 'test_*.pan')):
             fn = basename(afn)
             if fn.startswith('test_good'):
                 self.assertEqual(panlint.lint_file(afn), no_errors)


### PR DESCRIPTION
This fixes a regression introduced when lines became objects and the references in this line were not updated correctly.

Fixes #230 and I believe it therefore fixes #224.