### PR TITLE
pan-book: correct formatting error

### DIFF
--- a/panc-docs/source/pan-book/pan-book.rst
+++ b/panc-docs/source/pan-book/pan-book.rst
@@ -1422,7 +1422,7 @@ child::
 
 
 The indices can be specified in decimal (digits only).
-Leading ``0``(s) (e.g. octal notation) are considered ambiguous
+Leading zeros (e.g. octal notation) are considered ambiguous
 and as such invalid.
 The names of children in an dict can be any string that has at
 least one non-digit character, starts with a so-called ``word``-character


### PR DESCRIPTION
I noticed a formatting error in the Resources section. Replace the digit 0 with the text zeros to eliminate it.