### PR TITLE
panlint: Don't require component source files to include component config

### DIFF
--- a/panc/src/main/scripts/panlint/panlint.py
+++ b/panc/src/main/scripts/panlint/panlint.py
@@ -51,6 +51,10 @@ RE_HEREDOC = re.compile(r'<<(\w+);\s*$.*?\1$', re.S | re.M)
 # Find usage and inclusion of components
 RE_COMPONENT_INCLUDE = re.compile(r'^\s*[^#]?\s*include.*components/(?P<name>\w+)/config', re.M)
 RE_COMPONENT_USE = re.compile(r'/software/components/(?P<name>\w+)/')
+
+# Detect whether a file is part of the source tree of a component
+RE_COMPONENT_SOURCE_FILE = re.compile(r'^/?(?:\S+/)?(?:core/components/|ncm-)(?P<name>\w+)/\S+$')
+
 LINE_LENGTH_LIMIT = 120
 
 # Simple regular-expression based checks that will be performed against all non-ignored lines
@@ -469,6 +473,10 @@ def lint_file(filename, allow_mvn_templates=False):
 
     # Get list of all component configs included in template
     components_included = RE_COMPONENT_INCLUDE.findall(raw_text)
+
+    # Is the current file part of the source tree of a component?
+    # If so, regard the component config as being included
+    components_included += RE_COMPONENT_SOURCE_FILE.findall(filename)
 
     for line_number, line_text in enumerate(raw_text.splitlines(), start=1):
         line = Line(filename, line_number, line_text.rstrip('\n'))

--- a/panc/src/main/scripts/panlint/tests.py
+++ b/panc/src/main/scripts/panlint/tests.py
@@ -353,6 +353,38 @@ class TestPanlint(unittest.TestCase):
             ([], set(), 0, False)
         )
 
+    def test_component_source_file(self):
+        """ Test the regex designed to detect whether the template being linted is part of a component's source code """
+        rfa = panlint.RE_COMPONENT_SOURCE_FILE.findall
+
+        # These tests should all find component names
+        self.assertEqual(
+            rfa('/var/quattor/cfg/plenary/template-library/18.6.0/core/components/shorewall/sysconfig.pan'),
+            ['shorewall'],
+        )
+        self.assertEqual(
+            rfa('./ncm-metaconfig/src/main/metaconfig/nginx/tests/profiles/config.pan'),
+            ['metaconfig'],
+        )
+        self.assertEqual(
+            rfa('./configuration-modules-core/ncm-opennebula/src/main/resources/tests/profiles/remoteconf_ceph.pan'),
+            ['opennebula'],
+        )
+        self.assertEqual(
+            rfa('ncm-network/src/test/resources/actions.pan'),
+            ['network'],
+        )
+
+        # These tests should NOT find component names
+        self.assertEqual(
+            rfa('features/monitoring/grafana/config.pan'),
+            [],
+        )
+        self.assertEqual(
+            rfa('./service/profileserver/client/config.pan'),
+            [],
+        )
+
     def test_check_line_patterns(self):
         lines = [
             ('variable UNIVERSAL_TRUTH = 42;', []),


### PR DESCRIPTION
This should cut out much of the rubbish flagged against test files etc. and obviate some of the need for #225.