### PR TITLE
panlint: Flag redundant use of format function within error or debug calls

### DIFF
--- a/panc/src/main/scripts/panlint/panlint.py
+++ b/panc/src/main/scripts/panlint/panlint.py
@@ -72,6 +72,7 @@ LINE_PATTERNS = {
     "Semicolons should be followed exactly one space or end-of-line": re.compile(r';(?P<error>(?:\S|\s{2,}))'),
     "Global variables should be uppercase": re.compile(r'variable\s+(?P<error>[\w]+)(?<=\S[a-z]\S)'),
     "Global variables should be five or more characters": re.compile(r'variable\s+(?P<error>\w{1,4})\b'),
+    "Redundant use of format within error or debug call": re.compile(r'(?:error|debug)\s*\(\s*(?P<error>format)\s*\('),
 }
 
 # Simple regular-expression based checks that will be performed against

--- a/panc/src/main/scripts/panlint/tests.py
+++ b/panc/src/main/scripts/panlint/tests.py
@@ -396,6 +396,10 @@ class TestPanlint(unittest.TestCase):
             ('variable camelCase = "camels!";', ['Global variables should be uppercase']),
             ('variable TitleCase ?= -3;', ['Global variables should be uppercase']),
             ('variable NoSpacesHere?=True;', ['Global variables should be uppercase']),
+            ('error(format("Duplicate %s in foo", mp));', ['Redundant use of format within error or debug call']),
+            ('error("is_asndate: invalid format for time");', []),
+            ('debug(format("%s: bar: %s", OBJECT, ARGV[0]));', ['Redundant use of format within error or debug call']),
+            ('debug("Foo" + bar + " has an unexpected format (should be a dict)");', []),
         ]
 
         for text, messages in lines:


### PR DESCRIPTION
Both `error` and `debug` have built in formatting.