### PR TITLE
panlint: Skip checks of operator if within a string

### DIFF
--- a/panc/src/main/scripts/panlint/panlint.py
+++ b/panc/src/main/scripts/panlint/panlint.py
@@ -116,7 +116,9 @@ class LineChecks:
             sqb_after = re.search(r'^([' + sqb_simple + ']*)[]]', chars_after)
 
             valid = True
-            if op == '-' and (
+            if inside_string(start, end, string_ranges):
+                continue
+            elif op == '-' and (
                     (
                         re.search(r'[^\w\s)=]\s*$', chars_before) and re.search(r'^\s*\d+\s*[^\w\s]', chars_after)
                     ) or (
@@ -145,7 +147,7 @@ class LineChecks:
                     start = sqb_before.start(1) + reg.start(0)
                     end = start + 1
 
-            elif not inside_string(start, end, string_ranges):
+            else:
                 reason = 'Missing'
                 if chars_before and chars_before[-1] not in (' ', '\t'):
                     valid = False

--- a/panc/src/main/scripts/panlint/test_files/test_good_structure.pan
+++ b/panc/src/main/scripts/panlint/test_files/test_good_structure.pan
@@ -14,3 +14,5 @@ dict(
         4123,
     ),
 );
+
+"name" = "Some string [foo-bar is bar+foo]";


### PR DESCRIPTION
I've changed the order of the 'if' statements. If the operator is within a string, we just skip it.

Fixes #240 