### PR TITLE
github/workflows: Remove branch restriction

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,10 +1,6 @@
 name: Python
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   tests:


### PR DESCRIPTION
This allows the tests to run on forks too.

As requested by @wpoely86.