### PR TITLE
Increase the number of operators an XPath expression can contain during tests

### DIFF
--- a/panc/pom.xml
+++ b/panc/pom.xml
@@ -94,6 +94,7 @@
             <exclude>**/TestUtils.java</exclude>
             <exclude>**/ScriptCompilerTest.java</exclude>
           </excludes>
+          <argLine>-Djdk.xml.xpathExprOpLimit=500</argLine>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
The `@expect` lines in the Pan unit tests contain very large xpath expressions which cannot be used with the default of 10.

Resolves #259.