### PR TITLE
panlint: Ignore length of bind lines

### DIFF
--- a/panc/src/main/scripts/panlint/panlint.py
+++ b/panc/src/main/scripts/panlint/panlint.py
@@ -92,7 +92,7 @@ LINE_PATTERNS = {
     "Use dicts instead of nlists": re.compile(r'\b(?P<error>(?:is_)?nlist)\s*\('),
     "Include statements no longer need curly braces": re.compile(r'''include\s+(?P<error>{[^;]+})'''),
     "Line is longer than %s characters" % LINE_LENGTH_LIMIT:
-    re.compile(r'''^.{0,%s}(?P<error>.*?)$''' % LINE_LENGTH_LIMIT),
+    re.compile(r'''^(?!bind ).{0,%s}(?P<error>.*?)$''' % LINE_LENGTH_LIMIT),
     "Commas should be followed by exactly one space": re.compile(r'(?P<error>,(?:\S|\s{2,}))'),
     "Whitespace before semicolon": re.compile(r'(?P<error>\s+;)'),
     "Semicolons should be followed exactly one space or end-of-line": re.compile(r';(?P<error>(?:\S|\s{2,}))'),

--- a/panc/src/main/scripts/panlint/tests.py
+++ b/panc/src/main/scripts/panlint/tests.py
@@ -482,6 +482,8 @@ class TestPanlint(unittest.TestCase):
             ('error("is_asndate: invalid format for time");', []),
             ('debug(format("%s: bar: %s", OBJECT, ARGV[0]));', ['Redundant use of format within error or debug call']),
             ('debug("Foo" + bar + " has an unexpected format (should be a dict)");', []),
+            ('"/software/components/metaconfig/services/{/etc/example_service_with_long_name/conf.d/dropin_config.cfg}/contents/foo" = "bar";', ['Line is longer than 120 characters']),
+            ('bind "/software/components/metaconfig/services/{/etc/example_service_with_long_name/conf.d/dropin_config.cfg}/contents" = type_example_service;', []),
         ]
 
         for text, messages in lines:


### PR DESCRIPTION
These are often required to be very long due to binds being made deep into the profile path. There is is no good way to refactor these, so they should not be flagged.