### PR TITLE
Updates to allow build of docs for pan 10.8

### DIFF
--- a/panc-docs/.readthedocs.yaml
+++ b/panc-docs/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: panc-docs/source/conf.py
+
+python:
+  install:
+    - requirements: panc-docs/requirements.txt

--- a/panc-docs/pom.xml
+++ b/panc-docs/pom.xml
@@ -53,6 +53,25 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.5.4</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/panc-docs/pom.xml
+++ b/panc-docs/pom.xml
@@ -33,9 +33,9 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>io.airlift.maven.plugins</groupId>
+        <groupId>kr.motd.maven</groupId>
         <artifactId>sphinx-maven-plugin</artifactId>
-        <version>2.1</version>
+        <version>2.10.0</version>
         <configuration>
           <sourceDirectory>source</sourceDirectory>
         </configuration>

--- a/panc-docs/requirements.txt
+++ b/panc-docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx_rtd_theme

--- a/panc-docs/source/conf.py
+++ b/panc-docs/source/conf.py
@@ -26,6 +26,7 @@ import os
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx_rtd_theme',
     'sphinx.ext.doctest',
     'sphinx.ext.todo',
 ]
@@ -44,7 +45,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Quattor'
-copyright = u'2014, Quattor Collaboration'
+copyright = u'2025, Quattor Collaboration'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -98,7 +99,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/panc-maven-archetype/pom.xml
+++ b/panc-maven-archetype/pom.xml
@@ -44,6 +44,25 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.5.4</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/panc-maven-plugin/pom.xml
+++ b/panc-maven-plugin/pom.xml
@@ -56,6 +56,25 @@
           </tags>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.5.4</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/panc-rpm/pom.xml
+++ b/panc-rpm/pom.xml
@@ -87,6 +87,25 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.5.4</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/panc/pom.xml
+++ b/panc/pom.xml
@@ -35,6 +35,19 @@
               </rules>
             </configuration>
           </execution>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.5.4</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <description>Pan Language Tools</description>
   <url>http://quattor.org/</url>
   <prerequisites>
-    <maven>3.3.3</maven>
+    <maven>3.5.4</maven>
   </prerequisites>
   <licenses>
     <license>
@@ -298,7 +298,22 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>1.4.1</version>
+	  <version>3.5.0</version>
+          <executions>
+            <execution>
+              <id>enforce-maven</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <requireMavenVersion>
+                    <version>3.5.4</version>
+                  </requireMavenVersion>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
The `pan-10.8` tag already points at these changes and the resulting documentation is live at:
https://quattor-pan.readthedocs.io/en/pan-10.8/