### PR TITLE
panc: Adjust grammar to allow a single trailing comma in choice types

### DIFF
--- a/panc/src/main/jjtree/PanParser.jjt
+++ b/panc/src/main/jjtree/PanParser.jjt
@@ -713,7 +713,7 @@ org.quattor.pan.ttemplate.SourceRange typeSpec() #TypeSpec :
 org.quattor.pan.ttemplate.SourceRange baseTypeSpec() #BaseTypeSpec :
 { Token t = null, b=null, e=null; org.quattor.pan.utils.Range r = null; }
 {
-  t=<CHOICE> <LPAREN> stringLiteral() (<COMMA> stringLiteral())* e=<RPAREN>
+  t=<CHOICE> <LPAREN> stringLiteral() (LOOKAHEAD(2) <COMMA> stringLiteral())* [ <COMMA> ] e=<RPAREN>
   {
     jjtThis.setIdentifier(t.image);
     jjtThis.setSourceRange(PanParserUtils.sourceRangeFromTokens(t,(e!=null)?e:t));

--- a/panc/src/test/pan/Functionality/choice/choice18.pan
+++ b/panc/src/test/pan/Functionality/choice/choice18.pan
@@ -4,6 +4,11 @@
 
 object template choice18;
 
-type mychoice = choice("aa", "bb", "aaa", "bbb");
+type mychoice = choice(
+    "aa",
+    "bb",
+    "aaa",
+    "bbb",
+);
 bind '/x' = mychoice with length(SELF) == 3;
 '/x' = "aaa";

--- a/panc/src/test/pan/Functionality/choice/choice19.pan
+++ b/panc/src/test/pan/Functionality/choice/choice19.pan
@@ -4,6 +4,11 @@
 
 object template choice19;
 
-type mychoice = choice("aa", "bb", "aaa", "bbb");
+type mychoice = choice(
+    "aa",
+    "bb",
+    "aaa",
+    "bbb",
+);
 bind '/x' = mychoice with length(SELF) == 3;
 '/x' = "aa";

--- a/panc/src/test/pan/Functionality/choice/choice20.pan
+++ b/panc/src/test/pan/Functionality/choice/choice20.pan
@@ -4,6 +4,11 @@
 
 object template choice20;
 
-type mychoice = choice("aa", "bb", "aaa", "bbb");
+type mychoice = choice(
+    "aa",
+    "bb",
+    "aaa",
+    "bbb",
+);
 bind '/x' = mychoice with length(SELF) == 3;
 '/x' = "ddd";

--- a/panc/src/test/pan/Functionality/choice/choice21.pan
+++ b/panc/src/test/pan/Functionality/choice/choice21.pan
@@ -4,6 +4,11 @@
 
 object template choice21;
 
-type mychoice = choice("aa", "bb", "aaa", "bbb");
+type mychoice = choice(
+    "aa",
+    "bb",
+    "aaa",
+    "bbb",
+);
 bind '/x' = mychoice(3);
 '/x' = "aaa";

--- a/panc/src/test/pan/Functionality/choice/choice22.pan
+++ b/panc/src/test/pan/Functionality/choice/choice22.pan
@@ -4,6 +4,11 @@
 
 object template choice22;
 
-type mychoice = choice("aa", "bb", "aaa", "bbb");
+type mychoice = choice(
+    "aa",
+    "bb",
+    "aaa",
+    "bbb",
+);
 bind '/x' = mychoice(3);
 '/x' = "aa";


### PR DESCRIPTION
This allows longer lists of choices to be line-wrapped more cleanly.

Also add line breaks and trailing commas to several tests to ensure this is tested.

Resolves #253.