### PR TITLE
panc: Throw a nice error when matches is called with a single argument

### DIFF
--- a/panc/src/main/java/org/quattor/pan/dml/functions/Matches.java
+++ b/panc/src/main/java/org/quattor/pan/dml/functions/Matches.java
@@ -53,7 +53,7 @@ final public class Matches extends AbstractVariableMatcher {
 
 		// Optimize the operation if compile time constants are given for the
 		// regular expression and match flags.
-		if (operations.length > 0
+		if (operations.length > 1
 				&& operations[1] instanceof StringProperty
 				&& (operations.length < 3 || operations[2] instanceof StringProperty)) {
 			return StaticMatches.getInstance(sourceRange, operations);

--- a/panc/src/test/java/org/quattor/pan/dml/functions/MatchesTest.java
+++ b/panc/src/test/java/org/quattor/pan/dml/functions/MatchesTest.java
@@ -188,6 +188,11 @@ public class MatchesTest extends BuiltInFunctionTestUtils {
 	}
 
 	@Test(expected = SyntaxException.class)
+	public void invalidCallWithOneArgument() throws SyntaxException {
+		Matches.getInstance(null, StringProperty.getInstance("a"));
+	}
+
+	@Test(expected = SyntaxException.class)
 	public void invalidCallWithTooManyArguments() throws SyntaxException {
 		Matches.getInstance(null, StringProperty.getInstance("a"),
 				StringProperty.getInstance("b"), StringProperty

--- a/panc/src/test/pan/Functionality/regexp/regexp5.pan
+++ b/panc/src/test/pan/Functionality/regexp/regexp5.pan
@@ -1,0 +1,9 @@
+#
+# too few args should give a nice error message
+#
+# @expect=org.quattor.pan.exceptions.SyntaxException
+#
+
+object template regexp4;
+
+"/bug" = matches("12323");


### PR DESCRIPTION
Rather than an ugly stack trace.
This is basically the same fix made to match in 5fb981cd1d3d367df122a1ad3199359141ae4b64

Resolves #273.