### PR TITLE
panlint: Do not report blank first lines as being invalid

### DIFF
--- a/panc/src/main/scripts/panlint/panlint.py
+++ b/panc/src/main/scripts/panlint/panlint.py
@@ -521,7 +521,7 @@ def lint_line(line, components_included, first_line=False, allow_mvn_templates=F
                     Problem(0, len(line.text), Message(
                         'FL001',
                         SEV_ERROR,
-                        'First non-comment line must be the template type and name',
+                        'First non-blank, non-comment line must be the template type and name',
                     ))
                 )
     else:


### PR DESCRIPTION
The logic was fixed in 8f7c659fcdac7044e5fbe1190e5d04565518d1d4, but the message wasn't updated.