### PR TITLE
panc: Fixes for parseException and sourceRange

### DIFF
--- a/panc/src/main/java/org/quattor/pan/parser/ParseException.java
+++ b/panc/src/main/java/org/quattor/pan/parser/ParseException.java
@@ -28,7 +28,7 @@ import org.quattor.pan.ttemplate.SourceRange;
  * This exception is thrown when parse errors are encountered. You can
  * explicitly create objects of this exception type by calling the method
  * generateParseException in the generated parser.
- * 
+ *
  * You can modify this class to customize your error reporting mechanisms so
  * long as you retain the public fields.
  */
@@ -157,7 +157,7 @@ public class ParseException extends RuntimeException {
 			retval += currentToken.next.beginLine + "."
 					+ currentToken.next.beginColumn + "-"
 					+ currentToken.next.endLine + "."
-					+ currentToken.next.endLine + "]\n";
+					+ currentToken.next.endColumn + "]\n";
 		}
 		retval += "\nEncountered: ";
 		Token tok = currentToken.next;

--- a/panc/src/main/java/org/quattor/pan/parser/ParseException.java
+++ b/panc/src/main/java/org/quattor/pan/parser/ParseException.java
@@ -151,14 +151,10 @@ public class ParseException extends RuntimeException {
 		}
 		String retval = "parse error ";
 		retval += (file != null) ? "[" + file + ":" : "[?:";
-		if (sourceRange != null) {
-			retval += sourceRange.toString() + "]\n";
-		} else {
-			retval += currentToken.next.beginLine + "."
-					+ currentToken.next.beginColumn + "-"
-					+ currentToken.next.endLine + "."
-					+ currentToken.next.endColumn + "]\n";
-		}
+		if (sourceRange == null) {
+			sourceRange = PanParserUtils.sourceRangeFromTokens(currentToken.next, currentToken.next);
+		};
+		retval += sourceRange.toString() + "]\n";
 		retval += "\nEncountered: ";
 		Token tok = currentToken.next;
 		for (int i = 0; i < maxSize; i++) {

--- a/panc/src/main/java/org/quattor/pan/parser/ParseException.java
+++ b/panc/src/main/java/org/quattor/pan/parser/ParseException.java
@@ -129,8 +129,7 @@ public class ParseException extends RuntimeException {
 			msg.append("parse error [");
 			msg.append((file != null) ? file.toString() : "?");
 			msg.append(":");
-			msg.append((sourceRange != null) ? sourceRange.toString()
-					: "?");
+			msg.append((sourceRange != null) ? sourceRange.toString() : "?");
 			msg.append("]\n");
 			msg.append(super.getMessage());
 			return msg.toString();

--- a/panc/src/main/java/org/quattor/pan/ttemplate/SourceRange.java
+++ b/panc/src/main/java/org/quattor/pan/ttemplate/SourceRange.java
@@ -23,9 +23,9 @@ package org.quattor.pan.ttemplate;
 /**
  * Defines a range of characters within a source pan template that is used to
  * provide detailed error messages.
- * 
+ *
  * @author loomis
- * 
+ *
  */
 public class SourceRange {
 

--- a/panc/src/main/java/org/quattor/pan/ttemplate/SourceRange.java
+++ b/panc/src/main/java/org/quattor/pan/ttemplate/SourceRange.java
@@ -45,13 +45,13 @@ public class SourceRange {
 			throw new IllegalArgumentException("beginLine must be positive");
 		}
 		if (beginColumn < 1) {
-			throw new IllegalArgumentException("beginLine must be positive");
+			throw new IllegalArgumentException("beginColumn must be positive");
 		}
 		if (endLine < 1) {
 			throw new IllegalArgumentException("endLine must be positive");
 		}
 		if (endColumn < 1) {
-			throw new IllegalArgumentException("endLine must be positive");
+			throw new IllegalArgumentException("endColumn must be positive");
 		}
 
 		// Check that ending point is after (or the same as) the starting point.


### PR DESCRIPTION
Fixes the incorrect column number reported by some instances of `parse error`, for example, the following:
```pan
declaration template test2;

include 'quattor/types/component' + ;
```
Would previously be reported with an incorrect end column number (actually the end line number):
```parse
error [test2.pan:3.37-3.3]
```
This corrects that:
```
parse error [test2.pan:3.37-3.37]
```

Similar typos/copypasta are also fixed in the range checks for the `SourceRange` class.